### PR TITLE
feat: improve AI chatbot image icons and preserve chat state on tab switch

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 from services.chat import get_chat_response
 from services.weather import get_weather
+
 router = APIRouter()
+
 class Message(BaseModel):
     role: str
     content: str
@@ -11,6 +13,7 @@ class ChatRequest(BaseModel):
     messages: list[Message]
     lat: float | None = None
     lon: float | None = None
+    image: str | None = None
 
 @router.post("/chat")
 def chat(request: ChatRequest):
@@ -23,5 +26,5 @@ def chat(request: ChatRequest):
         except:
             pass
     
-    response = get_chat_response(messages, weather)
+    response = get_chat_response(messages, weather, request.image)
     return {"response": response}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,6 @@ charset-normalizer==3.4.7
 click==8.3.2
 cryptography==47.0.0
 deprecation==2.1.0
-distro==1.9.0
 dnspython==2.8.0
 email-validator==2.3.0
 fastapi==0.135.3
@@ -18,7 +17,6 @@ fastapi-cloud-cli==0.16.1
 fastar==0.11.0
 fsspec==2026.3.0
 greenlet==3.4.0
-groq==1.2.0
 h11==0.16.0
 h2==4.3.0
 hpack==4.1.0
@@ -61,7 +59,6 @@ rignore==0.7.6
 sentry-sdk==2.58.0
 shellingham==1.5.4
 six==1.17.0
-sniffio==1.3.1
 SQLAlchemy==2.0.49
 starlette==1.0.0
 storage3==2.29.0
@@ -81,3 +78,4 @@ watchfiles==1.1.1
 websockets==15.0.1
 yarl==1.23.0
 zstandard==0.25.0
+groq==1.2.0

--- a/backend/services/chat.py
+++ b/backend/services/chat.py
@@ -32,17 +32,45 @@ When answering:
 - Use emojis occasionally to feel warm and human, but don't overdo it
 - Match the user's energy — if they're casual and playful, be playful back
 
+When identifying a plant from an image:
+- Identify the plant name (common and scientific)
+- Describe its key characteristics briefly
+- Give care tips: sunlight, watering, soil
+- Mention any interesting facts or warnings
+- Suggest companion plants if relevant
+- If it IS a plant: identify the name (common and scientific), describe its key characteristics briefly, give care tips (sunlight, watering, soil), mention any interesting facts or warnings, and suggest companion plants if relevant
+- If it is NOT a plant: clearly acknowledge what you actually see in the image (e.g. "That looks like a medicine box, not a plant! 😄") and then invite them to share a plant photo instead
 
-If a question is not about gardening, say: "I'm specialized in garden planning — feel free to ask me anything about plants, soil, or garden design!" """
 
-def get_chat_response(messages: list, weather: dict | None = None) -> str:
+If a question is not about gardening and no image is involved, politely say you specialize in plants and gardens and ask them to try a gardening question.
+
+"""
+
+def get_chat_response(messages: list, weather: dict | None = None, image: str | None = None) -> str:
     system = SYSTEM_PROMPT
     if weather:
-        system += f"\n\nUser's current weather: Temperature: {weather['temperature']}°C, Humidity: {weather['humidity']}%, Precipitation: {weather['precipitation']}mm, Wind: {weather['wind_speed']} km/h. Use this to give relevant gardening advice without mentioning you received this data."
-    
+        system += f"\n\nUser is located in {weather['city']}, {weather['country']}. Current weather: {weather['temperature']}°C, humidity {weather['humidity']}%, precipitation {weather['precipitation']}mm, wind {weather['wind_speed']} km/h. Use this context naturally in your advice."
+
+    if image:
+        model = "meta-llama/llama-4-scout-17b-16e-instruct"
+        last_message = messages[-1] if messages else {"role": "user", "content": "What plant is this?"}
+        groq_messages = [
+            {"role": "system", "content": system},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": last_message["content"] or "What plant is this? Give me details and care tips."},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image}"}}
+                ]
+            }
+        ]
+    else:
+        model = "llama-3.3-70b-versatile"
+        groq_messages = [{"role": "system", "content": system}] + messages
+
     response = client.chat.completions.create(
-        model="llama-3.3-70b-versatile",
-        messages=[{"role": "system", "content": system}] + messages,
+        model=model,
+        messages=groq_messages,
         max_tokens=500,
     )
     return response.choices[0].message.content

--- a/frontend/src/components/AIChatbot.tsx
+++ b/frontend/src/components/AIChatbot.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 interface Message {
   role: 'user' | 'assistant'
   content: string
+  image?: string
 }
 
 interface Location {
@@ -15,6 +16,13 @@ export default function AIChatbot() {
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [location, setLocation] = useState<Location | null>(null)
+  const [pendingImage, setPendingImage] = useState<string | null>(null)
+  const [showImageOptions, setShowImageOptions] = useState(false)
+  const [showCamera, setShowCamera] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const streamRef = useRef<MediaStream | null>(null)
 
   useEffect(() => {
     if (navigator.geolocation) {
@@ -25,13 +33,67 @@ export default function AIChatbot() {
     }
   }, [])
 
-  const sendMessage = async () => {
-    if (!input.trim()) return
+  const handleImageFile = (file: File) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const base64 = (e.target?.result as string).split(',')[1]
+      setPendingImage(base64)
+    }
+    reader.readAsDataURL(file)
+  }
 
-    const userMessage: Message = { role: 'user', content: input }
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData.items
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        const file = item.getAsFile()
+        if (file) handleImageFile(file)
+      }
+    }
+  }
+
+  const openCamera = async () => {
+    setShowImageOptions(false)
+    setShowCamera(true)
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true })
+      streamRef.current = stream
+      if (videoRef.current) videoRef.current.srcObject = stream
+    } catch {
+      alert('Could not access camera.')
+      setShowCamera(false)
+    }
+  }
+
+  const capturePhoto = () => {
+    if (!videoRef.current || !canvasRef.current) return
+    const canvas = canvasRef.current
+    canvas.width = videoRef.current.videoWidth
+    canvas.height = videoRef.current.videoHeight
+    canvas.getContext('2d')?.drawImage(videoRef.current, 0, 0)
+    const base64 = canvas.toDataURL('image/jpeg').split(',')[1]
+    setPendingImage(base64)
+    closeCamera()
+  }
+
+  const closeCamera = () => {
+    streamRef.current?.getTracks().forEach(t => t.stop())
+    streamRef.current = null
+    setShowCamera(false)
+  }
+
+  const sendMessage = async () => {
+    if (!input.trim() && !pendingImage) return
+
+    const userMessage: Message = {
+      role: 'user',
+      content: input || 'What plant is this?',
+      image: pendingImage ?? undefined
+    }
     const updatedMessages = [...messages, userMessage]
     setMessages(updatedMessages)
     setInput('')
+    setPendingImage(null)
     setLoading(true)
 
     try {
@@ -39,9 +101,10 @@ export default function AIChatbot() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          messages: updatedMessages,
+          messages: updatedMessages.map(m => ({ role: m.role, content: m.content })),
           lat: location?.lat ?? null,
           lon: location?.lon ?? null,
+          image: userMessage.image ?? null,
         }),
       })
       const data = await res.json()
@@ -55,32 +118,86 @@ export default function AIChatbot() {
 
   return (
     <div className="flex flex-col h-full p-3 gap-2">
-      <div className="flex-1 overflow-y-auto flex flex-col gap-2">
-        {messages.length === 0 && (
-          <p className="text-gray-500 text-sm text-center mt-4">Ask me anything about your garden!</p>
-        )}
-        {messages.map((m, i) => (
-          <div key={i} className={`text-sm p-2 rounded-lg max-w-[90%] ${m.role === 'user' ? 'bg-green-800 self-end' : 'bg-gray-700 self-start'}`}>
-            {m.content}
+      {showCamera && (
+        <div className="flex flex-col gap-2">
+          <video ref={videoRef} autoPlay className="rounded w-full" />
+          <canvas ref={canvasRef} className="hidden" />
+          <div className="flex gap-2">
+            <button onClick={capturePhoto} className="flex-1 bg-green-600 hover:bg-green-500 text-white text-sm py-1 rounded">Take Photo</button>
+            <button onClick={closeCamera} className="flex-1 bg-gray-600 hover:bg-gray-500 text-white text-sm py-1 rounded">Cancel</button>
           </div>
-        ))}
-        {loading && <div className="text-gray-400 text-sm self-start">Thinking...</div>}
-      </div>
-      <div className="flex gap-2">
-        <input
-          className="flex-1 bg-gray-800 text-white text-sm rounded px-3 py-2 outline-none"
-          placeholder="Ask about plants, soil, layout..."
-          value={input}
-          onChange={e => setInput(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && sendMessage()}
-        />
-        <button
-          onClick={sendMessage}
-          className="bg-green-600 hover:bg-green-500 text-white text-sm px-3 py-2 rounded"
-        >
-          Send
-        </button>
-      </div>
+        </div>
+      )}
+
+      {!showCamera && (
+        <>
+          <div className="flex-1 overflow-y-auto flex flex-col gap-2">
+            {messages.length === 0 && (
+              <p className="text-gray-500 text-sm text-center mt-4">Ask me anything about your garden!</p>
+            )}
+            {messages.map((m, i) => (
+              <div key={i} className={`text-sm p-2 rounded-lg max-w-[90%] ${m.role === 'user' ? 'bg-green-800 self-end' : 'bg-gray-700 self-start'}`}>
+                {m.image && <img src={`data:image/jpeg;base64,${m.image}`} alt="plant" className="rounded mb-1 max-w-full max-h-32 object-cover" />}
+                {m.content}
+              </div>
+            ))}
+            {loading && <div className="text-gray-400 text-sm self-start">Thinking...</div>}
+          </div>
+
+          {pendingImage && (
+            <div className="relative w-16 h-16">
+              <img src={`data:image/jpeg;base64,${pendingImage}`} alt="preview" className="w-16 h-16 object-cover rounded" />
+              <button onClick={() => setPendingImage(null)} className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full w-4 h-4 text-xs flex items-center justify-center">×</button>
+            </div>
+          )}
+
+          {showImageOptions && (
+            <div className="flex gap-2 bg-gray-800 p-2 rounded">
+              <button onClick={() => { fileInputRef.current?.click(); setShowImageOptions(false) }} className="flex-1 text-sm text-white bg-gray-700 hover:bg-gray-600 py-1 rounded flex items-center justify-center gap-1">
+  <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+    <polyline points="17 8 12 3 7 8"/>
+    <line x1="12" y1="3" x2="12" y2="15"/>
+  </svg>
+  Upload
+</button>
+<button onClick={openCamera} className="flex-1 text-sm text-white bg-gray-700 hover:bg-gray-600 py-1 rounded flex items-center justify-center gap-1">
+  <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/>
+    <circle cx="12" cy="13" r="4"/>
+  </svg>
+  Capture
+</button>
+
+            </div>
+          )}
+
+          <div className="flex gap-2 items-center">
+            <button onClick={() => setShowImageOptions(!showImageOptions)} className="text-gray-400 hover:text-white px-1">
+  <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"/>
+    <circle cx="8.5" cy="8.5" r="1.5"/>
+    <polyline points="21 15 16 10 5 21"/>
+  </svg>
+</button>
+
+            <input
+
+              className="flex-1 bg-gray-800 text-white text-sm rounded px-3 py-2 outline-none"
+              placeholder="Ask or paste an image..."
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && sendMessage()}
+              onPaste={handlePaste}
+              onFocus={() => setShowImageOptions(false)}
+
+            />
+            <button onClick={sendMessage} className="bg-green-600 hover:bg-green-500 text-white text-sm px-3 py-2 rounded">Send</button>
+          </div>
+        </>
+      )}
+
+      <input ref={fileInputRef} type="file" accept="image/*" className="hidden" onChange={e => e.target.files?.[0] && handleImageFile(e.target.files[0])} />
     </div>
   )
 }

--- a/frontend/src/components/FeaturePanel.tsx
+++ b/frontend/src/components/FeaturePanel.tsx
@@ -10,28 +10,28 @@ export default function FeaturePanel() {
       <div className="flex border-b border-gray-700 w-full">
         <button
           onClick={() => setActiveTab('chat')}
-          className={`flex-1 py-2 text-sm font-medium transition-colors ${
-            activeTab === 'chat'
+          className={`flex-1 py-2 text-sm font-medium transition-colors ${activeTab === 'chat'
               ? 'text-green-400 border-b-2 border-green-400'
               : 'text-gray-400 hover:text-white'
-          }`}
+            }`}
         >
           AI Chatbot
         </button>
         <button
           onClick={() => setActiveTab('plants')}
-          className={`flex-1 py-2 text-sm font-medium transition-colors ${
-            activeTab === 'plants'
+          className={`flex-1 py-2 text-sm font-medium transition-colors ${activeTab === 'plants'
               ? 'text-green-400 border-b-2 border-green-400'
               : 'text-gray-400 hover:text-white'
-          }`}
+            }`}
         >
           Plant Library
         </button>
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {activeTab === 'chat' ? <AIChatbot /> : <PlantLibrary />}
+        <div className={activeTab === 'chat' ? 'h-full' : 'hidden'}><AIChatbot /></div>
+        <div className={activeTab === 'plants' ? 'h-full' : 'hidden'}><PlantLibrary /></div>
+
       </div>
     </div>
   )


### PR DESCRIPTION
Implemented image upload and camera capture buttons for AI chatbot recognition.
Replaced the plain text “Upload” and “Capture” buttons with SVG icons to improve the user experience.
Fixed the issue where chat history was lost when switching between the AI Chatbot and Plant Library tabs. Both components are now kept mounted and toggled using CSS instead of being unmounted.
